### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,81 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when a release is created
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+on:
+  release:
+    types: [created]
+
+name: Deploy to Amazon ECS
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: my-ecr-repo
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: sample-app
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: sample-app-service
+        cluster: default
+        wait-for-service-stability: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,9 @@ jobs:
         with:
           node-version: '12.x'
       
-      # Run single commands using the runner's shell
-      - name: Install dependencies
-        run: npm install
+      # Run commands using the runner's shell
       - name: Run ${{ matrix.command }} command in ${{ matrix.directory }} directory
         run: |
+          npm install
           cd ${{ matrix.directory }}
           npm run ${{ matrix.command }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,11 @@ jobs:
       matrix:
         directory: [application, Service]
         command: [lint, test]
+    
+    defaults:
+      # Set working directory where commands are run
+      run:
+        working-directory: ${{ matrix.directory }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -42,9 +47,8 @@ jobs:
         with:
           node-version: '12.x'
       
-      # Run commands using the runner's shell
+      # Run single commands using the runner's shell
+      - name: Install dependencies
+        run: npm install
       - name: Run ${{ matrix.command }} command in ${{ matrix.directory }} directory
-        run: |
-          npm install
-          cd ${{ matrix.directory }}
-          npm run ${{ matrix.command }}
+        run: npm run ${{ matrix.command }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,7 @@ jobs:
       # Run single commands using the runner's shell
       - name: Install dependencies
         run: npm install
-      - name: Move into directory
-        run: cd ${{ matrix.directory }}
-      - name: Debug current directory
-        run: ls
-      - name: Run ${{ matrix.command }} command
-        run: npm run ${{ matrix.command }}
+      - name: Run ${{ matrix.command }} command in ${{ matrix.directory }} directory
+        run: |
+          cd ${{ matrix.directory }}
+          npm run ${{ matrix.command }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+# Get .env variables from our repository's secrets
+env:
+  NODE_ENV: dev
+  DB_USER: ${{ secrets.DB_USER }}
+  DB_PASS: ${{ secrets.DB_PASS }}
+  DB_NAME: ${{ secrets.DB_NAME }}
+
+# Run CI on pull request for the main branches
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'dev'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  LintAndTest :
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    strategy:
+      # Continue even if a case fails
+      fail-fast: false
+      # This job will run for each of these cases (each combination of values for the variables `directory` & `command`)
+      matrix:
+        directory: ['application', 'Service']
+        command: ['lint', 'test']
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Setup node
+      - name: Setup Node.js v12
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      
+      # Run single commands using the runner's shell
+      - name: Install dependencies
+        run: npm install
+      - name: Move into directory
+        run: cd ${{ matrix.directory }}
+      - name: Run ${{ matrix.command }} command
+        run: npm run ${{ matrix.command }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
       # This job will run for each of these cases (each combination of values for the variables `directory` & `command`)
       matrix:
-        directory: ['application', 'Service']
-        command: ['lint', 'test']
+        directory: [application, Service]
+        command: [lint, test]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -47,5 +47,7 @@ jobs:
         run: npm install
       - name: Move into directory
         run: cd ${{ matrix.directory }}
+      - name: Debug current directory
+        run: ls
       - name: Run ${{ matrix.command }} command
         run: npm run ${{ matrix.command }}


### PR DESCRIPTION
- Set up a basic workflow to run lint & unit tests on both application & Service folders whenever a PR is made on `master` or `dev` branches.
- Also set up a basic template for deploying to Amazon ECS (this was one of the basic templates offered by GitHub so I figured I might as well add it and Carter can decide later if we want to use it). Currently, the trigger is a GitHub "release" so it shouldn't do anything for now.

For more info about the syntax of these `.yml` action files, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions).